### PR TITLE
Be more explicit when ignoring dirs and allow file ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Many of the options are optional since they can be added directly to the `compos
    [--username=USERNAME] \
    [--password=PASSWORD] \
    [--ignore-dirs=test]\
-   [--ignore-dirs=foo]
+   [--ignore-dirs=foo/bar]\
+   [--ignore-files=config/local.php]\
+   [--ignore-files=foo/bar.php]\
    <version>
    
  # Example
@@ -34,7 +36,10 @@ It's possible to add some configurations inside the `composer.json` file:
             "password": "admin123",
             "ignore-dirs": [
                 "test",
-                "foo"
+                "foo/bar"
+            ],
+            "ignore-files": [
+                "config/local.php"
             ]
         }
     }

--- a/README.md
+++ b/README.md
@@ -15,14 +15,12 @@ Many of the options are optional since they can be added directly to the `compos
    [--url=<URL to the composer nexus repository>] \
    [--username=USERNAME] \
    [--password=PASSWORD] \
-   [--ignore-dirs=test]\
-   [--ignore-dirs=foo/bar]\
-   [--ignore-files=config/local.php]\
-   [--ignore-files=foo/bar.php]\
+   [--ignore=test.php]\
+   [--ignore=foo/]\
    <version>
    
  # Example
- $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository/composer --ignore-dirs=test --ignore-dirs=foo 0.0.1
+ $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository/composer --ignore=test.php --ignore=foo/ 0.0.1
  ```
 
 ## Configuration
@@ -34,12 +32,9 @@ It's possible to add some configurations inside the `composer.json` file:
             "url": "http://localhost:8081/repository/composer/",
             "username": "admin",
             "password": "admin123",
-            "ignore-dirs": [
-                "test",
-                "foo/bar"
-            ],
-            "ignore-files": [
-                "config/local.php"
+            "ignore": [
+                "test.php",
+                "foo/"
             ]
         }
     }

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -342,6 +342,12 @@ EOT
         }
     }
 
+    /**
+     * Fetch any directories or files to be excluded from zip creation
+     *
+     * @param InputInterface $input
+     * @return array
+     */
     private function getIgnores(InputInterface $input)
     {
         // Remove after removal of --ignore-dirs option

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -37,7 +37,8 @@ class PushCommand extends BaseCommand
                 'Username to log in the distant Nexus repository'
             ),
             new InputOption('password', null, InputArgument::OPTIONAL, 'Password to log in the distant Nexus repository'),
-            new InputOption('ignore-dirs', 'i', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Directories to ignore when creating the zip')
+            new InputOption('ignore-dirs', 'i', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Directories to ignore when creating the zip'),
+            new InputOption('ignore-files', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Files to ignore when creating the zip')
           ])
           ->setHelp(
               <<<EOT
@@ -69,6 +70,7 @@ EOT
         ));
 
         $ignoredDirectories = $this->getDirectoriesToIgnore($input);
+        $ignoredFiles = $this->getFilesToIgnore($input);
 
         try {
             ZipArchiver::archiveDirectory(
@@ -76,6 +78,7 @@ EOT
                 $fileName,
                 $subdirectory,
                 $ignoredDirectories,
+                $ignoredFiles,
                 $this->getIO()
           );
 
@@ -351,6 +354,15 @@ EOT
         $composerIgnores = $this->getNexusExtra('ignore-dirs', []);
 
         $ignore = array_merge($composerIgnores, $optionalIgnore, ['vendor']);
+        return array_unique($ignore);
+    }
+
+    private function getFilesToIgnore(InputInterface $input)
+    {
+        $optionalIgnore = $input->getOption('ignore-files');
+        $composerIgnores = $this->getNexusExtra('ignore-files', []);
+
+        $ignore = array_merge($composerIgnores, $optionalIgnore);
         return array_unique($ignore);
     }
 }

--- a/src/ZipArchiver.php
+++ b/src/ZipArchiver.php
@@ -18,8 +18,8 @@ class ZipArchiver
      * @param string $destination archive destination
      * @param string $subDirectory subdirectory in which the sources will be
      *               archived. If null, put at the root of the directory.
-     * @param array $ignorePatterns
-     *
+     * @param array $ignoreDirectories
+     * @param array $ignoreFiles
      * @param \Composer\IO\IOInterface|null $io
      *
      * @throws \Exception
@@ -28,7 +28,8 @@ class ZipArchiver
         $source,
         $destination,
         $subDirectory = null,
-        $ignorePatterns = [],
+        $ignoreDirectories = [],
+        $ignoreFiles = [],
         $io = null
     ) {
         if (empty($io)) {
@@ -46,8 +47,12 @@ class ZipArchiver
 
         $finder->in($source)->ignoreVCS(true);
 
-        foreach ($ignorePatterns as $ignorePattern) {
-            $finder->notPath($ignorePattern);
+        foreach ($ignoreDirectories as $ignoreDirectory) {
+            $finder->exclude($ignoreDirectory);
+        }
+
+        foreach ($ignoreFiles as $ignoreFile) {
+            $finder->notPath($ignoreFile);
         }
 
         $archive = new \ZipArchive();

--- a/src/ZipArchiver.php
+++ b/src/ZipArchiver.php
@@ -18,8 +18,7 @@ class ZipArchiver
      * @param string $destination archive destination
      * @param string $subDirectory subdirectory in which the sources will be
      *               archived. If null, put at the root of the directory.
-     * @param array $ignoreDirectories
-     * @param array $ignoreFiles
+     * @param array $ignores
      * @param \Composer\IO\IOInterface|null $io
      *
      * @throws \Exception
@@ -28,8 +27,7 @@ class ZipArchiver
         $source,
         $destination,
         $subDirectory = null,
-        $ignoreDirectories = [],
-        $ignoreFiles = [],
+        $ignores = [],
         $io = null
     ) {
         if (empty($io)) {
@@ -47,13 +45,10 @@ class ZipArchiver
 
         $finder->in($source)->ignoreVCS(true);
 
-        foreach ($ignoreDirectories as $ignoreDirectory) {
-            $finder->exclude($ignoreDirectory);
+        foreach ($ignores as $ignore) {
+            $finder->notPath($ignore);
         }
 
-        foreach ($ignoreFiles as $ignoreFile) {
-            $finder->notPath($ignoreFile);
-        }
 
         $archive = new \ZipArchive();
 


### PR DESCRIPTION
We have issues with files that contain `test` in their name being excluded from packages when we specify `test` as an ignore directory due it to using `notPath` filter under the hood.

Have modified it so that directory ignores are handle via the `exclude` filter so it's more explicit and adding a new option to allow use of the `notPath` filter with the ignore-files option. 

