### PR TITLE
add param repo-type to support upload to different repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Many of the options are optional since they can be added directly to the `compos
  # At the root of your directory
  $ composer nexus-push [--name=<package name>] \
    [--url=<URL to the composer nexus repository>] \
-   [--repo-type=<the repository name you want to save, use this parameter if you want to place development version and production version in different repository on one Nexus >] \
+   [--repository=<the repository you want to save, use this parameter if you want to control which repository to upload to by command-line parameter>] \
    [--username=USERNAME] \
    [--password=PASSWORD] \
    [--ignore=test.php]\
@@ -30,16 +30,12 @@ Many of the options are optional since they can be added directly to the `compos
  ```
 
 ## Configuration
-It's possible to add some configurations inside the `composer.json` file:
+It's possible to add some configurations inside the `composer.json` file
 ```json
 {
     "extra": {
         "nexus-push": {
             "url": "http://localhost:8081/repository/",
-            "repo-list": {
-                "dev": "composer-devs",
-                "prod": "composer"
-            },
             "username": "admin",
             "password": "admin123",
             "ignore-by-git-attributes": true,
@@ -51,5 +47,39 @@ It's possible to add some configurations inside the `composer.json` file:
     }
 }
 ```
+Above configuration may be called unique repository configuration format, as you can only configue one nexus repository in composer.json.  
+
+In practice, for security reasons, different versions of component code, such as production and development, often apply different deployment policy, such as disable redeploy for the production version and allow redeploy for the development version, so they need to be stored in different nexus repositories.
+For versions later than 0.1.5, the command-line parameter -- repository is introduced to meet this requirement. To enable the -- repository parameter, the composer.json file needs to be in the following format:
+```json
+{
+	"extra": {
+		"nexus-push": [{
+			"name": "prod",
+			"url": "http://localhost:8081/repository/composer-releases",
+			"username": "admin",
+			"password": "admin123",
+			"ignore-by-git-attributes": true,
+			"ignore": [
+				"test.php",
+				"foo/"
+			]
+		}, {
+			"name": "dev",
+			"url": "http://localhost:8081/repository/composer-devs",
+			"username": "admin",
+			"password": "admin123",
+			"ignore-by-git-attributes": true,
+			"ignore": [
+				"test.php",
+				"foo/"
+			]
+		}]
+	}
+}
+```
+Above configuration may be called unique repository configuration format.  
+
+The new version continues to support parsing the old unique repository configuration format, but remember that you cannot use the -- repository command line argument.  
 
 The `username` and `password` can be specified in the `auth.json` file on a per-user basis with the [authentication mechanism provided by Composer](https://getcomposer.org/doc/articles/http-basic-authentication.md).

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Many of the options are optional since they can be added directly to the `compos
    
  # Example 
  $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository/composer --ignore=test.php --ignore=foo/ 0.0.1
- # use repo-type Example 
- # concreate repository name is configured in composer.json of the project,see value of key "repo-list" in the bellow Configuration part
- # if --repo-type is not offered, reposotory name is setted by param --url as above exapmple shown 
- $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository --repo-type=prod --ignore=test.php --ignore=foo/ 0.0.1
+ 
+ # Example of use --repository
+ # you need firstly configure multi repositories in composer.json of the project.
+ # Please refer to Configuration below (multi repository configuration format) for configuration method
+ # The component will be uploaded to the first repository whose's name value matching -- repository value
+ # If there is no matching between the value of repository name and the value of -- repository, the upload will fail with a prompt
+ $ composer nexus-push --username=admin --password=admin123 --repository=prod --ignore=test.php --ignore=foo/ 0.0.1
  ```
 
 ## Configuration
@@ -35,7 +38,7 @@ It's possible to add some configurations inside the `composer.json` file
 {
     "extra": {
         "nexus-push": {
-            "url": "http://localhost:8081/repository/",
+            "url": "http://localhost:8081/repository/composer",
             "username": "admin",
             "password": "admin123",
             "ignore-by-git-attributes": true,
@@ -53,33 +56,33 @@ In practice, for security reasons, different versions of component code, such as
 For versions later than 0.1.5, the command-line parameter -- repository is introduced to meet this requirement. To enable the -- repository parameter, the composer.json file needs to be in the following format:
 ```json
 {
-	"extra": {
-		"nexus-push": [{
-			"name": "prod",
-			"url": "http://localhost:8081/repository/composer-releases",
-			"username": "admin",
-			"password": "admin123",
-			"ignore-by-git-attributes": true,
-			"ignore": [
-				"test.php",
-				"foo/"
-			]
-		}, {
-			"name": "dev",
-			"url": "http://localhost:8081/repository/composer-devs",
-			"username": "admin",
-			"password": "admin123",
-			"ignore-by-git-attributes": true,
-			"ignore": [
-				"test.php",
-				"foo/"
-			]
-		}]
-	}
+    "extra": {
+        "nexus-push": [{
+            "name": "prod",
+            "url": "http://localhost:8081/repository/composer-releases",
+            "username": "admin",
+            "password": "admin123",
+            "ignore-by-git-attributes": true,
+            "ignore": [
+                "test.php",
+                "foo/"
+            ]
+        }, {
+            "name": "dev",
+            "url": "http://localhost:8081/repository/composer-devs",
+            "username": "admin",
+            "password": "admin123",
+            "ignore-by-git-attributes": true,
+            "ignore": [
+                "test.php",
+                "foo/"
+            ]
+        }]
+    }
 }
 ```
-Above configuration may be called unique repository configuration format.  
+Above configuration may be called multi repository configuration format.  
 
-The new version continues to support parsing the old unique repository configuration format, but remember that you cannot use the -- repository command line argument.  
+The new version continues to support parsing the unique repository configuration format, but remember that you cannot use the -- repository command line argument in this scenario.  
 
 The `username` and `password` can be specified in the `auth.json` file on a per-user basis with the [authentication mechanism provided by Composer](https://getcomposer.org/doc/articles/http-basic-authentication.md).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Many of the options are optional since they can be added directly to the `compos
  # At the root of your directory
  $ composer nexus-push [--name=<package name>] \
    [--url=<URL to the composer nexus repository>] \
+   [--repo-type=<the repository name you want to save, if you want to place development version and production version in different Nexus repositoryo>] \
    [--username=USERNAME] \
    [--password=PASSWORD] \
    [--ignore=test.php]\
@@ -20,8 +21,12 @@ Many of the options are optional since they can be added directly to the `compos
    [--ignore-by-git-attributes]
    <version>
    
- # Example
+ # Example 
  $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository/composer --ignore=test.php --ignore=foo/ 0.0.1
+ # use repo-type Example 
+ # concreate repository name is configured in composer.json of the project,see value of key "repo-list" key in the next Configuration part
+# if --repo-type is not offered, reposotory name is setted by param --url as above exapmple shown 
+ $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository --repo-type=prod --ignore=test.php --ignore=foo/ 0.0.1
  ```
 
 ## Configuration
@@ -31,6 +36,10 @@ It's possible to add some configurations inside the `composer.json` file:
     "extra": {
         "nexus-push": {
             "url": "http://localhost:8081/repository/composer/",
+            "repo-list": {
+                "dev": "composer-devs",
+                "prod": "composer"
+            },
             "username": "admin",
             "password": "admin123",
             "ignore-by-git-attributes": true,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Many of the options are optional since they can be added directly to the `compos
  $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository/composer --ignore=test.php --ignore=foo/ 0.0.1
  # use repo-type Example 
  # concreate repository name is configured in composer.json of the project,see value of key "repo-list" key in the next Configuration part
-# if --repo-type is not offered, reposotory name is setted by param --url as above exapmple shown 
+ # if --repo-type is not offered, reposotory name is setted by param --url as above exapmple shown 
  $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository --repo-type=prod --ignore=test.php --ignore=foo/ 0.0.1
  ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Many of the options are optional since they can be added directly to the `compos
  # At the root of your directory
  $ composer nexus-push [--name=<package name>] \
    [--url=<URL to the composer nexus repository>] \
-   [--repo-type=<the repository name you want to save, if you want to place development version and production version in different Nexus repositoryo>] \
+   [--repo-type=<the repository name you want to save, use this parameter if you want to place development version and production version in different repository on one Nexus >] \
    [--username=USERNAME] \
    [--password=PASSWORD] \
    [--ignore=test.php]\
@@ -24,7 +24,7 @@ Many of the options are optional since they can be added directly to the `compos
  # Example 
  $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository/composer --ignore=test.php --ignore=foo/ 0.0.1
  # use repo-type Example 
- # concreate repository name is configured in composer.json of the project,see value of key "repo-list" key in the next Configuration part
+ # concreate repository name is configured in composer.json of the project,see value of key "repo-list" in the bellow Configuration part
  # if --repo-type is not offered, reposotory name is setted by param --url as above exapmple shown 
  $ composer nexus-push --username=admin --password=admin123 --url=http://localhost:8081/repository --repo-type=prod --ignore=test.php --ignore=foo/ 0.0.1
  ```
@@ -35,7 +35,7 @@ It's possible to add some configurations inside the `composer.json` file:
 {
     "extra": {
         "nexus-push": {
-            "url": "http://localhost:8081/repository/composer/",
+            "url": "http://localhost:8081/repository/",
             "repo-list": {
                 "dev": "composer-devs",
                 "prod": "composer"

--- a/src/InvalidConfigException.php
+++ b/src/InvalidConfigException.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace Elendev\NexusComposerPush;
+
+class InvalidConfigException extends \LogicException
+{
+}

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -114,7 +114,6 @@ EOT
 
             $url = $this->generateUrl(
                 $input->getOption('url'),
-                $input->getOption(self::REPOSITORY),
                 $packageName,
                 $input->getArgument('version')
             );
@@ -147,13 +146,12 @@ EOT
 
     /**
      * @param string $url
-     * @param string $repository
      * @param string $name
      * @param string $version
      *
      * @return string URL to the repository
      */
-    private function generateUrl($url, $repository, $name, $version)
+    private function generateUrl($url, $name, $version)
     {
         if (empty($url)) {
             $url = $this->getNexusExtra('url');

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -443,6 +443,8 @@ EOT
                 if(empty($this->nexusPushConfig)){
                     throw new InvalidArgumentException('The value of option --repository match no nexus-push configuration, pleash check');
                 }
+
+                return $this->nexusPushConfig;
             }
         }catch (\Exception $e){
             $this->getIO()
@@ -451,7 +453,7 @@ EOT
         }
     }
 
-    public function checkNexusPushValid(InputInterface $input){
+    private function checkNexusPushValid(InputInterface $input){
         $repository = $input->getOption(self::REPOSITORY);
         $extras = $this->getComposer(true)->getPackage()->getExtra();
         if(empty($repository) && !empty($extras['nexus-push'][0])){

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use Elendev\NexusComposerPush\InvalidConfigException;
 
 class PushCommand extends BaseCommand
 {
@@ -33,6 +34,14 @@ class PushCommand extends BaseCommand
      */
     private $globalVendorDir;
 
+    /**
+     * @var
+     */
+    private $nexusPushConfig = array();
+
+    const REPOSITORY = 'repository';
+    const PUSH_CFG_NAME = 'name';
+
     protected function configure()
     {
         $this
@@ -42,7 +51,7 @@ class PushCommand extends BaseCommand
             new InputArgument('version', InputArgument::REQUIRED, 'The package version'),
             new InputOption('name', null, InputArgument::OPTIONAL, 'Name of the package (if different from the composer.json file)'),
             new InputOption('url', null, InputArgument::OPTIONAL, 'URL to the distant Nexus repository'),
-            new InputOption('repo-type', null, InputArgument::OPTIONAL, 'repository to save, use this parameter if you want to place development version and production version in different repository on one Nexus'),
+            new InputOption(self::REPOSITORY, null, InputArgument::OPTIONAL, 'which repository to save, use this parameter if you want to place development version and production version in different repository'),
             new InputOption(
                 'username',
                 null,
@@ -101,9 +110,11 @@ EOT
                 $this->getIO()
           );
 
+            $this->parseNexusExtra($input);
+
             $url = $this->generateUrl(
                 $input->getOption('url'),
-                $input->getOption('repo-type'),
+                $input->getOption(self::REPOSITORY),
                 $packageName,
                 $input->getArgument('version')
             );
@@ -136,13 +147,13 @@ EOT
 
     /**
      * @param string $url
-     * @param string $repoType
+     * @param string $repository
      * @param string $name
      * @param string $version
      *
      * @return string URL to the repository
      */
-    private function generateUrl($url, $repoType, $name, $version)
+    private function generateUrl($url, $repository, $name, $version)
     {
         if (empty($url)) {
             $url = $this->getNexusExtra('url');
@@ -150,18 +161,6 @@ EOT
             if (empty($url)) {
                 throw new InvalidArgumentException('The option --url is required or has to be provided as an extra argument in composer.json');
             }
-        }
-
-        if(!empty($repoType)){
-            $repoLists = $this->getNexusExtra('repo-list');
-            if(!is_array($repoLists)){
-                throw new InvalidArgumentException('The option --repo-type is offered but "repo-list" in composer.json is not array');
-            }
-            if(!isset($repoLists[$repoType])){
-                throw new InvalidArgumentException('The option --repo-type is offered but "repo-list" in composer.json does not contain key with the given value');
-            }
-
-            $url = rtrim($url,"/").'/'.$repoLists[$repoType];
         }
 
         if (empty($name)) {
@@ -416,6 +415,56 @@ EOT
     }
 
     /**
+     * @param InputInterface $input
+     */
+    private function parseNexusExtra(InputInterface $input){
+        try{
+            $this->checkNexusPushValid($input);
+
+            $repository = $input->getOption(self::REPOSITORY);
+            $extras = $this->getComposer(true)->getPackage()->getExtra();
+            if(empty($repository)){
+                // configurations in composer.json support Only upload to unique repository
+                if(!empty($extras['nexus-push'])){
+                    $this->nexusPushConfig = $extras['nexus-push'];
+                }
+
+            }else{
+                // configurations in composer.json support upload to multi repository
+                foreach ($extras['nexus-push'] as $key=> $nexusPushConfigItem){
+                    if(empty($nexusPushConfigItem[self::PUSH_CFG_NAME])){
+                        $fmt = 'The nexus-push configuration array in composer.json with index {%s} need provide value for key "%s"';
+                        $exceptionMsg = sprintf($fmt,$key,self::PUSH_CFG_NAME);
+                        throw new InvalidConfigException($exceptionMsg);
+                    }
+                    if($nexusPushConfigItem[self::PUSH_CFG_NAME] ==$repository){
+                        $this->nexusPushConfig = $nexusPushConfigItem;
+                    }
+                }
+
+                if(empty($this->nexusPushConfig)){
+                    throw new InvalidArgumentException('The value of option --repository match no nexus-push configuration, pleash check');
+                }
+            }
+        }catch (\Exception $e){
+            $this->getIO()
+                ->write($e->getMessage());
+            throw $e;
+        }
+    }
+
+    public function checkNexusPushValid(InputInterface $input){
+        $repository = $input->getOption(self::REPOSITORY);
+        $extras = $this->getComposer(true)->getPackage()->getExtra();
+        if(empty($repository) && !empty($extras['nexus-push'][0])){
+            throw new InvalidArgumentException('As configurations in composer.json support upload to multi repository, the option --repository is required');
+        }
+        if(!empty($repository) && empty($extras['nexus-push'][0])){
+            throw new InvalidConfigException('the option --repository is offered, but configurations in composer.json doesn\'t support upload to multi repository, please check');
+        }
+    }
+
+    /**
      * Get the Nexus extra values if available
      *
      * @param $parameter
@@ -425,10 +474,8 @@ EOT
      */
     private function getNexusExtra($parameter, $default = null)
     {
-        $extras = $this->getComposer(true)->getPackage()->getExtra();
-
-        if (!empty($extras['nexus-push'][$parameter])) {
-            return $extras['nexus-push'][$parameter];
+        if (!empty($this->nexusPushConfig[$parameter])) {
+            return $this->nexusPushConfig[$parameter];
         } else {
             return $default;
         }

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -467,6 +467,10 @@ EOT
 
     /**
      * Get the Nexus extra values if available
+
+     * Important notice:
+     * the method parseNexusExtra has to be called to initialize $this->nexusPushConfig
+     * before being able to call this method
      *
      * @param $parameter
      * @param null $default

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -443,9 +443,10 @@ EOT
                 if(empty($this->nexusPushConfig)){
                     throw new InvalidArgumentException('The value of option --repository match no nexus-push configuration, pleash check');
                 }
-
-                return $this->nexusPushConfig;
             }
+
+            return $this->nexusPushConfig;
+
         }catch (\Exception $e){
             $this->getIO()
                 ->write($e->getMessage());

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -42,7 +42,7 @@ class PushCommand extends BaseCommand
             new InputArgument('version', InputArgument::REQUIRED, 'The package version'),
             new InputOption('name', null, InputArgument::OPTIONAL, 'Name of the package (if different from the composer.json file)'),
             new InputOption('url', null, InputArgument::OPTIONAL, 'URL to the distant Nexus repository'),
-            new InputOption('repo-type', null, InputArgument::OPTIONAL, 'repository to save , if you want to place development version and production version in different Nexus repository'),
+            new InputOption('repo-type', null, InputArgument::OPTIONAL, 'repository to save, use this parameter if you want to place development version and production version in different repository on one Nexus'),
             new InputOption(
                 'username',
                 null,
@@ -155,10 +155,10 @@ EOT
         if(!empty($repoType)){
             $repoLists = $this->getNexusExtra('repo-list');
             if(!is_array($repoLists)){
-                throw new InvalidArgumentException('The option --repo-type is offered or but repo-list is in composer.json is not array');
+                throw new InvalidArgumentException('The option --repo-type is offered but "repo-list" in composer.json is not array');
             }
             if(!isset($repoLists[$repoType])){
-                throw new InvalidArgumentException('The option --repo-type is is offered but the value is not key of repo-list in composer.json');
+                throw new InvalidArgumentException('The option --repo-type is offered but "repo-list" in composer.json does not contain key with the given value');
             }
 
             $url = rtrim($url,"/").'/'.$repoLists[$repoType];


### PR DESCRIPTION
Hello，
In practice, we usually put the components of development and production versions in different repositories of the private nexus platform, like maven. I added a new parameter "repo-type", so that we can control which repository to upload to through the command-line parameter. The function has been tested. Can you merge the code into the master. I'm glad to discuss with you about this problem. Thanks for your time。