### PR TITLE
Make composer.json extra opts work for ignoring.

### DIFF
--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -94,6 +94,8 @@ EOT
             $packageName . '-' . $input->getArgument('version')
         ));
 
+        $this->parseNexusExtra($input);
+
         $ignoredDirectories = $this->getIgnores($input);
         $this->getIO()
             ->write(
@@ -110,8 +112,6 @@ EOT
                 $ignoredDirectories,
                 $this->getIO()
             );
-
-            $this->parseNexusExtra($input);
 
             $url = $this->generateUrl(
                 $input->getOption('url'),


### PR DESCRIPTION
`parseNexusExtra` has to be executed before `getIgnores`, otherwise extra config is always empty ans so does ignores (from composer.json).