### PR TITLE
Declare PHP 8 compatibility

### DIFF
--- a/.github/actions/php-8.0/Dockerfile
+++ b/.github/actions/php-8.0/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:8.0-rc-cli
+
+RUN apt-get update && apt-get install -y libz-dev
+
+RUN docker-php-ext-install zip

--- a/.github/workflows/testing-and-cs.yaml
+++ b/.github/workflows/testing-and-cs.yaml
@@ -12,6 +12,10 @@ jobs:
         uses: docker://composer:1.9
         with:
           args: install
+      - name: 'Composer add code sniffer'
+        uses: docker://composer:1.9
+        with:
+          args: "require --dev friendsofphp/php-cs-fixer ^2.14"
       - name: 'Code sniffing'
         uses: docker://php:7.2-cli
         with:
@@ -23,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         composer: [1.6, 1.7, 1.8, 1.9, 1.10, 2.0]
         symfony: [^3.0, ^4.0, ^5.0]
     steps:

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
         "psr-4": {"Elendev\\NexusComposerPush\\": "src/"}
     },
     "require": {
-        "php": ">=7.2 <7.5",
+        "php": ">=7.2 || ^8.0",
         "ext-curl": "*",
+        "ext-json": "*",
         "ext-zip": "*",
         "composer-plugin-api": "^1.1|^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
@@ -24,8 +25,7 @@
         "class": "Elendev\\NexusComposerPush\\Plugin"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^8",
-        "composer/composer": "^1.8"
+        "phpunit/phpunit": "^8 || ^9",
+        "composer/composer": "^1.8 || ^2.0"
     }
 }


### PR DESCRIPTION
Here's a WIP on compatibility with PHP 8.0

- removal of fixer because of https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702
- added json to requirements because `\Elendev\NexusComposerPush\PushCommand::getComposerJsonArchiveExcludeIgnores()` using `json_decode`
- phpunit 9.4.2 passed test on PHP 8.0 rc2