### PR TITLE
change composer address from the "data-dir" configuration item to "home"

### DIFF
--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -433,7 +433,7 @@ EOT
             $vendorDir = $this->getGlobalVendorDir();
             $vendorFile = $vendorDir . $file;
             if (!file_exists($vendorFile)) {
-                throw new FileNotFoundException("$file not found, is guzzle installed?");
+                throw new FileNotFoundException("$file not found, is guzzle globally installed?");
             }
         }
 

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -410,7 +410,7 @@ EOT
     {
         if (!$this->globalVendorDir) {
             $composer  = $this->getComposer(true);
-            $vendorDir = $composer->getConfig()->get('data-dir') . '/' . $composer->getConfig()->get('vendor-dir', Config::RELATIVE_PATHS);
+            $vendorDir = $composer->getConfig()->get('home') . '/' . $composer->getConfig()->get('vendor-dir', Config::RELATIVE_PATHS);
 
             // Show an error if the file wasn't found in the current project.
             if (file_exists($vendorDir . '/elendev/nexus-composer-push')) {


### PR DESCRIPTION
HI, I made two changes。
1、modify global FileNotFoundException error message， so that user can distinguish from the above exception
2、read the composer address from the "home" configuration item instead of "data-dir".
     According to composer document https://getcomposer.org/doc/06-config.md#data-dir, "data-dir" is now only used for storing past composer.phar files to be able to rollback to older versions and "home" represents the installation directory of composer.

thanks for your time!